### PR TITLE
Default additional_data to a string

### DIFF
--- a/tasks/create_incident.rb
+++ b/tasks/create_incident.rb
@@ -13,7 +13,7 @@ class SnowCreateIncident < TaskHelper
   def task(urgency: nil,
            priority: nil,
            severity: nil,
-           additional_data: {},
+           additional_data: '{}',
            _target: nil,
            **_kwargs)
     user = _target[:user]


### PR DESCRIPTION
Previous to this commit, the create_incident task defaulted the
additional_data parameter to a Ruby hash. In the task,
JSON.parse(addition_data) is called which expects a string.

This commit defaults the additiona_data parameter to a string, so it's
parsed as valid JSON