### PR TITLE
Fix ServiceNowRequest load path

### DIFF
--- a/tasks/create_record.json
+++ b/tasks/create_record.json
@@ -2,7 +2,7 @@
     "puppet_task_version": 1,
     "supports_noop": false,
     "description": "Create a ServiceNow record",
-    "files": ["ruby_task_helper/files/task_helper.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
     "remote": true,
     "parameters": {
         "table": {

--- a/tasks/create_record.rb
+++ b/tasks/create_record.rb
@@ -1,7 +1,7 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
 require_relative '../../ruby_task_helper/files/task_helper.rb'
-require '../lib/service_now_request.rb'
+require_relative '../lib/service_now_request.rb'
 
 # This task creates records
 class ServiceNowCreate < TaskHelper

--- a/tasks/delete_record.json
+++ b/tasks/delete_record.json
@@ -3,7 +3,7 @@
     "supports_noop": false,
     "description": "Delete a Servicenow record",
     "remote": true,
-    "files": ["ruby_task_helper/files/task_helper.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
     "parameters": {
         "table": {
             "description": "ServiceNow table",

--- a/tasks/delete_record.rb
+++ b/tasks/delete_record.rb
@@ -1,7 +1,7 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
 require_relative '../../ruby_task_helper/files/task_helper.rb'
-require '../lib/service_now_request.rb'
+require_relative '../lib/service_now_request.rb'
 
 # This task deletes a record from a given table with a given sys_id
 class ServiceNowDelete < TaskHelper

--- a/tasks/get_record.json
+++ b/tasks/get_record.json
@@ -3,7 +3,7 @@
     "supports_noop": false,
     "description": "Get a ServiceNow record",
     "remote": true,
-    "files": ["ruby_task_helper/files/task_helper.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
     "parameters": {
         "table": {
             "description": "ServiceNow table",

--- a/tasks/get_record.rb
+++ b/tasks/get_record.rb
@@ -1,7 +1,7 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
 require_relative '../../ruby_task_helper/files/task_helper.rb'
-require '../lib/service_now_request.rb'
+require_relative '../lib/service_now_request.rb'
 
 # This task reads incidents
 class ServiceNowGet < TaskHelper

--- a/tasks/update_record.json
+++ b/tasks/update_record.json
@@ -2,7 +2,7 @@
     "puppet_task_version": 1,
     "supports_noop": false,
     "description": "Update a ServiceNow record",
-    "files": ["ruby_task_helper/files/task_helper.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
     "remote": true,
     "parameters": {
         "table": {

--- a/tasks/update_record.rb
+++ b/tasks/update_record.rb
@@ -1,7 +1,7 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
 require_relative '../../ruby_task_helper/files/task_helper.rb'
-require '../lib/service_now_request.rb'
+require_relative '../lib/service_now_request.rb'
 
 # This task updates records
 class ServiceNowUpdate < TaskHelper


### PR DESCRIPTION
servicenow_tasks uses the ruby task helper module which requires that
files used by each task, such as the ServiceNowRequest class in the lib
folder, be listed in the task metadata under the files parameter.
service_now_request.rb has now been added to each tasks metadata and
required via a require relative.