### PR TITLE
(PIE-252) Allow auth to be passed via params

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,20 @@ nodes:
         password: "XHxH2tmZ69*Vbh"
 ```
 
+Tasks can also be executed via puppet by specifying `user`, `password`, and `instance` parameters. Credentials specified via parameters will take precedence over any in an inventory file.
+
 ## Usage
 
 To get a record from the incident table with sys_id = `3Db9b91557db00101096dde37a48961976`
 
 ```bash
 bolt task run --nodes dev84270 servicenow_tasks::get_record table=incident sys_id=3Db9b91557db00101096dde37a48961976
+```
+
+or without an inventory file,
+
+```bash
+bolt task run --nodes dev84270 servicenow_tasks::get_record user=my_username password=my_password instance=my_instance table=incident sys_id=3Db9b91557db00101096dde37a48961976
 ```
 
 Further example usage is provided via `bolt task show`

--- a/tasks/create_record.json
+++ b/tasks/create_record.json
@@ -12,6 +12,19 @@
         "fields": {
             "description": "ServiceNow fields. This is a hash of <field_name> => <value>",
             "type": "Hash[Any, Any, 1]"
+        },
+        "user": {
+            "description": "ServiceNow username",
+            "type": "Optional[String[1]]"
+        },
+        "password": {
+            "description": "ServiceNow password",
+            "type": "Optional[String[1]]",
+            "sensitive": true
+        },
+        "instance": {
+            "description": "ServiceNow instance name. If your instance uri is https://dev84270.service-now.com your instance name would be dev84270.",
+            "type": "Optional[String[1]]"
         }
     }
 }

--- a/tasks/create_record.rb
+++ b/tasks/create_record.rb
@@ -7,12 +7,16 @@ require_relative '../lib/service_now_request.rb'
 class ServiceNowCreate < TaskHelper
   def task(table: nil,
            fields: nil,
+           user: nil,
+           password: nil,
+           instance: nil,
            _target: nil,
            **_kwargs)
 
-    user = _target[:user]
-    password = _target[:password]
-    instance = _target[:name]
+    # Use the inventory file credentials if no user, password, or instance is passed in via parameters.
+    user = _target[:user] if user.nil?
+    password = _target[:password] if password.nil?
+    instance = _target[:name] if instance.nil?
 
     uri = "https://#{instance}.service-now.com/api/now/table/#{table}"
 

--- a/tasks/delete_record.json
+++ b/tasks/delete_record.json
@@ -12,6 +12,19 @@
         "sys_id": {
             "description": "ServiceNow sys_id",
             "type": "String[1]"
+        },
+        "user": {
+            "description": "ServiceNow username",
+            "type": "Optional[String[1]]"
+        },
+        "password": {
+            "description": "ServiceNow password",
+            "type": "Optional[String[1]]",
+            "sensitive": true
+        },
+        "instance": {
+            "description": "ServiceNow instance name. If your instance uri is https://dev84270.service-now.com your instance name would be dev84270.",
+            "type": "Optional[String[1]]"
         }
     }
 }

--- a/tasks/delete_record.rb
+++ b/tasks/delete_record.rb
@@ -7,12 +7,16 @@ require_relative '../lib/service_now_request.rb'
 class ServiceNowDelete < TaskHelper
   def task(table: nil,
            sys_id: nil,
+           user: nil,
+           password: nil,
+           instance: nil,
            _target: nil,
            **_kwargs)
 
-    user = _target[:user]
-    password = _target[:password]
-    instance = _target[:name]
+    # Use the inventory file credentials if no user, password, or instance is passed in via parameters.
+    user = _target[:user] if user.nil?
+    password = _target[:password] if password.nil?
+    instance = _target[:name] if instance.nil?
 
     uri = "https://#{instance}.service-now.com/api/now/table/#{table}/#{sys_id}"
 

--- a/tasks/get_record.json
+++ b/tasks/get_record.json
@@ -12,6 +12,19 @@
         "sys_id": {
             "description": "ServiceNow sys_id",
             "type": "String[1]"
+        },
+        "user": {
+            "description": "ServiceNow username",
+            "type": "Optional[String[1]]"
+        },
+        "password": {
+            "description": "ServiceNow password",
+            "type": "Optional[String[1]]",
+            "sensitive": true
+        },
+        "instance": {
+            "description": "ServiceNow instance name. If your instance uri is https://dev84270.service-now.com your instance name would be dev84270.",
+            "type": "Optional[String[1]]"
         }
     }
 }

--- a/tasks/get_record.rb
+++ b/tasks/get_record.rb
@@ -7,12 +7,16 @@ require_relative '../lib/service_now_request.rb'
 class ServiceNowGet < TaskHelper
   def task(table: nil,
            sys_id: nil,
+           user: nil,
+           password: nil,
+           instance: nil,
            _target: nil,
            **_kwargs)
 
-    user = _target[:user]
-    password = _target[:password]
-    instance = _target[:name]
+    # Use the inventory file credentials if no user, password, or instance is passed in via parameters.
+    user = _target[:user] if user.nil?
+    password = _target[:password] if password.nil?
+    instance = _target[:name] if instance.nil?
 
     uri = "https://#{instance}.service-now.com/api/now/table/#{table}/#{sys_id}"
 

--- a/tasks/update_record.json
+++ b/tasks/update_record.json
@@ -16,6 +16,19 @@
         "fields": {
             "description": "ServiceNow fields to be updated. This is a hash of <field_name> => <value>",
             "type": "Hash[Any, Any, 1]"
+        },
+        "user": {
+            "description": "ServiceNow username",
+            "type": "Optional[String[1]]"
+        },
+        "password": {
+            "description": "ServiceNow password",
+            "type": "Optional[String[1]]",
+            "sensitive": true
+        },
+        "instance": {
+            "description": "ServiceNow instance name. If your instance uri is https://dev84270.service-now.com your instance name would be dev84270.",
+            "type": "Optional[String[1]]"
         }
     }
 }

--- a/tasks/update_record.rb
+++ b/tasks/update_record.rb
@@ -8,12 +8,16 @@ class ServiceNowUpdate < TaskHelper
   def task(table: nil,
            sys_id: nil,
            fields: nil,
+           user: nil,
+           password: nil,
+           instance: nil,
            _target: nil,
            **_kwargs)
 
-    user = _target[:user]
-    password = _target[:password]
-    instance = _target[:name]
+    # Use the inventory file credentials if no user, password, or instance is passed in via parameters.
+    user = _target[:user] if user.nil?
+    password = _target[:password] if password.nil?
+    instance = _target[:name] if instance.nil?
 
     uri = "https://#{instance}.service-now.com/api/now/table/#{table}/#{sys_id}"
 


### PR DESCRIPTION
In order to make this module compatible with PE, you can now pass a
username, password, and instance via task parameters rather than an
inventory file. If a username, password, or instance is not provided in
the parameters the values in the inventory file will be used. Parameter
credentials are prioritized over those provided in an inventory file.