### PR TITLE
Initial attempt at adding external datasource

### DIFF
--- a/files/get-snow-node-data.rb
+++ b/files/get-snow-node-data.rb
@@ -1,0 +1,18 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'yaml'
+require_relative '../lib/service_now_request.rb'
+
+if $PROGRAM_NAME == __FILE__
+  puts '{"environment" : "yolo"}'
+  # config = YAML.load_file('/etc/puppetlabs/puppet/snow_record.yaml')
+
+  # snowinstance = config['snowinstance']
+  # table = config['table']
+  # sys_id = config['sys_id']
+
+  # uri = "https://#{snowinstance}.service-now.com/api/now/table/#{table}/#{sys_id}"
+
+  # request = ServiceNowRequest.new(uri, 'Get', nil, user, password)
+  # request.print_response
+end

--- a/lib/service_now_request.rb
+++ b/lib/service_now_request.rb
@@ -35,6 +35,6 @@ class ServiceNowRequest
       puts [pretty_response]
     end
   rescue => e
-    raise TaskHelper::Error.new('Failure!', 'servicenow_tasks.print_response', e)
+    raise TaskHelper::Error.new('Failure!', 'servicenow_integration.print_response', e)
   end
 end

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -1,0 +1,55 @@
+class servicenow_integration::puppetserver (
+  String $snowinstance,
+  String $user,
+  String $password,
+  String $table,
+  String $sys_id
+) {
+  $gem_build_dependencies = (
+    package { ['make', 'automake', 'gcc', 'gcc-c++', 'kernel-devel']:
+      ensure => present,
+    }
+  )
+
+  $resource_dependencies = flatten([
+    ['puppet_gem', 'puppetserver_gem'].map |$provider| {
+      package { "${provider} cassandra-driver":
+        ensure   => present,
+        name     => 'cassandra-driver',
+        provider => $provider,
+        require  => $gem_build_dependencies,
+      }
+    },
+
+    file { '/etc/puppetlabs/puppet/get-snow-node-data.rb':
+      ensure => file,
+      owner  => 'pe-puppet',
+      group  => 'pe-puppet',
+      mode   => '0755',
+      source => 'puppet:///modules/servicenow_integration/get-snow-node-data.rb',
+    },
+
+    file { '/etc/puppetlabs/puppet/snow_record.yaml':
+      ensure  => file,
+      owner   => 'pe-puppet',
+      group   => 'pe-puppet',
+      mode    => '0640',
+      content => epp('servicenow_integration/snow_record.yaml.epp', {
+        snowinstance => $snowinstance,
+        user         => $user,
+        password     => $password,
+        table        => $table,
+        sys_id       => $sys_id
+      }),
+    },
+  ])
+
+  pe_ini_setting { 'puppetserver puppetconf trusted external script':
+    ensure  => present,
+    path    => '/etc/puppetlabs/puppet/puppet.conf',
+    setting => 'trusted_external_command',
+    value   => '/etc/puppetlabs/puppet/get-snow-nodedata.rb',
+    section => 'master',
+    require => $resource_dependencies,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "puppetlabs-servicenow_tasks",
+  "name": "puppetlabs-servicenow_integration",
   "version": "0.0.1",
   "author": "puppet",
   "summary": "Series of tasks to interact with a ServiceNow Instance",
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs/ruby_task_helper",
       "version_requirement": ">= 0.3.0 <= 2.0.0"
+    },
+    {
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">= 1.0"
     }
   ],
   "operatingsystem_support": [

--- a/tasks/create_record.json
+++ b/tasks/create_record.json
@@ -2,7 +2,7 @@
     "puppet_task_version": 1,
     "supports_noop": false,
     "description": "Create a ServiceNow record",
-    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_integration/lib/service_now_request.rb"],
     "remote": true,
     "parameters": {
         "table": {

--- a/tasks/delete_record.json
+++ b/tasks/delete_record.json
@@ -3,7 +3,7 @@
     "supports_noop": false,
     "description": "Delete a Servicenow record",
     "remote": true,
-    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_integration/lib/service_now_request.rb"],
     "parameters": {
         "table": {
             "description": "ServiceNow table",

--- a/tasks/get_record.json
+++ b/tasks/get_record.json
@@ -3,7 +3,7 @@
     "supports_noop": false,
     "description": "Get a ServiceNow record",
     "remote": true,
-    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_integration/lib/service_now_request.rb"],
     "parameters": {
         "table": {
             "description": "ServiceNow table",

--- a/tasks/update_record.json
+++ b/tasks/update_record.json
@@ -2,7 +2,7 @@
     "puppet_task_version": 1,
     "supports_noop": false,
     "description": "Update a ServiceNow record",
-    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_tasks/lib/service_now_request.rb"],
+    "files": ["ruby_task_helper/files/task_helper.rb", "servicenow_integration/lib/service_now_request.rb"],
     "remote": true,
     "parameters": {
         "table": {

--- a/templates/snow_record.yaml.epp
+++ b/templates/snow_record.yaml.epp
@@ -1,0 +1,13 @@
+<%- | String $snowinstance,
+      String $user,
+      String $password,
+      String $table,
+      String $sys_id
+| -%>
+---
+snowinstance: <%= $snowinstance %>
+snowinstance: <%= $snowinstance %>
+user: <%= $user %>
+password: <%= $password %>
+table: <%= $table %>
+sys_id: <%= $sys_id %>


### PR DESCRIPTION
This change adds the files need to enable this module to act as an
external data source for SNOW data.

It adds a manifest class that will configure puppet to look for a script
that will get the data, and it adds some configuration to allow the
script to run.

At this point we probably still need a better way to set the
configuration and we will need to set about writing the script itself.

All of the previously present SNOW bolt tasks are still in place and
will still provide useful tasks for people doing the integration.