### PR TITLE
(PIE-498) Add pdb query plan

### DIFF
--- a/lib/puppet/functions/servicenow_tasks/pdb_results.rb
+++ b/lib/puppet/functions/servicenow_tasks/pdb_results.rb
@@ -6,28 +6,26 @@ Puppet::Functions.create_function(:'servicenow_tasks::pdb_results') do
   end
 
   def pdb_results(node)
-    fact_map = {
-      # PuppetDB fact => ServiceNow CI field
-      'fqdn'                   => 'fqdn',
-      'domain'                 => 'dns_domain',
-      'serialnumber'           => 'serial_number',
-      'operatingsystemrelease' => 'os_version',
-      'physicalprocessorcount' => 'cpu_count',
-      'processorcount'         => 'cpu_core_count',
-      'processors.models.0'    => 'cpu_type',
-      'memorysize_mb'          => 'ram',
-      'is_virtual'             => 'virtual',
-      'macaddress'             => 'mac_address',
-    }
+   fact_map = {
+     # PuppetDB fact => ServiceNow CI field
+     'fqdn'                   => 'fqdn',
+     'domain'                 => 'dns_domain',
+     'serialnumber'           => 'serial_number',
+     'operatingsystemrelease' => 'os_version',
+     'physicalprocessorcount' => 'cpu_count',
+     'processorcount'         => 'cpu_core_count',
+     'processors.models.0'    => 'cpu_type',
+     'memorysize_mb'          => 'ram',
+     'is_virtual'             => 'virtual',
+     'macaddress'             => 'mac_address',
+   }
 
-    fact_query_filter = []
-    fact_map.keys.each do |fact|
-      fact_name = fact.split('.')[0]
-      fact_query_filter.push("name='#{fact_name}'")
-    end
-    query = "facts[name,value] { (#{fact_query_filter.join(' or ')}) and certname = '#{node}' }"
-    puppetdb_client = Puppet.lookup(:bolt_pdb_client)
-    # Query PuppetDB
-    puppetdb_client.make_query(query).to_json
+   fact_query_filter = []
+   fact_map.each do |fact, _field|
+     fact_name = fact.split('.')[0]
+     fact_query_filter.push("name='#{fact_name}'")
+   end
+   
+   "facts[name,value] { (#{fact_query_filter.join(' or ')}) and certname = '#{node}' }"
   end
 end

--- a/lib/puppet/functions/servicenow_tasks/tuple_to_json.rb
+++ b/lib/puppet/functions/servicenow_tasks/tuple_to_json.rb
@@ -1,0 +1,11 @@
+require 'json'
+
+Puppet::Functions.create_function(:'servicenow_tasks::tuple_to_json') do
+  dispatch :tuple_to_json do
+    required_param 'Tuple',  :data
+  end
+
+  def tuple_to_json(data)
+    data.to_json
+  end
+end

--- a/plans/create_ci_with_query.pp
+++ b/plans/create_ci_with_query.pp
@@ -6,8 +6,10 @@ plan servicenow_tasks::create_ci_with_query(
   Sensitive[String] $snow_oauth_token = Sensitive('')
 ){
 
+    $test_node = {'node' => $node}
+
   # Get results from PDB
-  $result_set = servicenow_tasks::pdb_results($node)
+  $result_set = run_plan(servicenow_tasks::fact_query, $test_node)
 
   $default_args = { 'table'              => 'cmdb_ci_server',
                     'instance'           => $snow_instance,

--- a/plans/fact_query.pp
+++ b/plans/fact_query.pp
@@ -1,0 +1,11 @@
+plan servicenow_tasks::fact_query(
+  String $node
+){
+  # Get results from PDB
+  #assign to variable and modify custom function to return the query instead of the results
+  $query = servicenow_tasks::pdb_results($node)
+
+  #Not sure how to return json from a plan, temp work around = custom function
+  return servicenow_tasks::tuple_to_json(puppetdb_query($query))
+
+}


### PR DESCRIPTION
This adds a plan that runs the pdb query independently. It uses the
results to create a CI in ServiceNow.