### PR TITLE
Parse url_params correctly

### DIFF
--- a/tasks/get_records.rb
+++ b/tasks/get_records.rb
@@ -23,7 +23,8 @@ class ServiceNowGetRecords < TaskHelper
       instance = _target[:name] if instance.nil?
     end
 
-    url_params ||= {}
+    url_params ||= {}.to_json
+    url_params = JSON.parse(url_params)
     url_params = url_params.map do |name, value|
       "#{CGI.escape(name.to_s)}=#{CGI.escape(value.to_s)}"
     end


### PR DESCRIPTION
The get_records task has a parameter called url params that expects a
json string. The json string was not being Parsed before having map
called on it.