### PR TITLE
(PIE-1270, PIE-1273) Add taks to read and write from common.yaml in h…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .envrc
 /inventory.yaml
 /Boltdir/
+*.log

--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -1,0 +1,3 @@
+---
+name: servicenow_tasks
+modules: []

--- a/plans/fact_query.pp
+++ b/plans/fact_query.pp
@@ -1,6 +1,6 @@
 plan servicenow_tasks::fact_query(
   String $node
-){
+) {
   # Get results from PDB
   $query = servicenow_tasks::pdb_results($node)
 

--- a/tasks/get_records.rb
+++ b/tasks/get_records.rb
@@ -32,7 +32,7 @@ class ServiceNowGetRecords < TaskHelper
 
     client = ServiceNow.new(instance, user: user, password: password, oauth_token: oauth_token)
     client.get_table_records(table, url_params)
-    end
+  end
 end
 
 if $PROGRAM_NAME == __FILE__

--- a/tasks/read_common.json
+++ b/tasks/read_common.json
@@ -1,0 +1,15 @@
+{
+  "description": "Parse common.yaml data from a given level or path.",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "parameters": {
+    "hiera_yaml_path": {
+      "description": "Absolute path to the directory containing the common.yaml file we are going to parse from.",
+      "type": "Optional[String]"
+    },
+    "create_new": {
+      "description": "Create common.yaml in given filepath if it does not exist",
+      "type": "Optional[Boolean]"
+    }
+    
+  }
+}

--- a/tasks/read_common.rb
+++ b/tasks/read_common.rb
@@ -1,0 +1,43 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require 'yaml'
+
+# This task reads common from a given path 
+##TODO add search by hiera level
+class ReadCommon < TaskHelper
+  def task(
+
+    hiera_yaml_path: "/etc/puppetlabs/code/environments/production/",
+    create_new: false,
+    **_kwargs)
+ 
+    hiera_yaml = YAML.load_file("#{hiera_yaml_path}/hiera.yaml")
+
+    datadir = 'data'
+    if defined? hiera_yaml["defaults"]["datadir"]
+      datadir = hiera_yaml["defaults"]["datadir"]
+    end
+    filename = "#{hiera_yaml_path}/#{datadir}/common.yaml"
+    if !File.file?(filename)
+      if !create_new
+        debug "hiera_yaml_path: #{hiera_yaml_path}"
+        debug "create_new: #{create_new}"
+        debug "common.yaml filepath: #{filename}"
+        raise TaskHelper::Error.new("Common File not Found",
+          "read_common/file-not-found",
+          "debug" => debug_statements)
+      else
+        File.open(filename, "w") do |f|
+          f.write("---  {}\n")   
+        end
+      end
+    end
+
+    common_data = YAML.load_file(filename)
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ReadCommon.run
+end

--- a/tasks/write_common.json
+++ b/tasks/write_common.json
@@ -1,0 +1,14 @@
+{
+  "description": "Write common.yaml data from a given level or path.",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "parameters": {
+    "hiera_yaml_path": {
+      "description": "Absolute path to the directory containing the common.yaml file we are going to write to.",
+      "type": "Optional[String]"
+    },
+    "data": {
+      "description": "Hashmap of data to be written to common, at minimum a single {Key:Value} pair",
+      "type": "Hash"
+    }
+  }
+}

--- a/tasks/write_common.rb
+++ b/tasks/write_common.rb
@@ -1,0 +1,41 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require 'yaml'
+
+# This task reads common from a given path 
+##TODO add search by hiera level
+class WriteCommon < TaskHelper
+  def task(
+
+    hiera_yaml_path: "/etc/puppetlabs/code/environments/production/",
+    data: {},
+    **_kwargs)
+ 
+    hiera_yaml = YAML.load_file("#{hiera_yaml_path}/hiera.yaml")
+
+    datadir = 'data'
+    if defined? hiera_yaml["defaults"]["datadir"]
+      datadir = hiera_yaml["defaults"]["datadir"]
+    end
+    filename = "#{hiera_yaml_path}/#{datadir}/common.yaml"
+    if !File.file?(filename)
+      debug "hiera_yaml_path: #{hiera_yaml_path}"
+      debug "create_new: #{create_new}"
+      debug "common.yaml filepath: #{filename}"
+      raise TaskHelper::Error.new("Common File not Found",
+        "read_common/file-not-found",
+        "debug" => debug_statements)
+    end
+    common_data = YAML.load_file(filename)
+    merged_data = common_data.merge(data)
+    File.open(filename, "w") do |f|
+      YAML.dump(merged_data, f) 
+    end
+    merged_data
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  WriteCommon.run
+end


### PR DESCRIPTION
…iera directory

The read_common and write_common tasks read and write, repsectively, to a common.yaml file in a given hiera directory. Both tasks take the path to a hiera.yaml file as input and find common.yaml by constructing the datadir path. if there is no common.yaml file found, read_common has an optional boolean to create one. write_common will fail if there is no common.yaml file found.

Write_common takes in put data in form of a hash, and merges the new data with any data already in common.yaml, overwriting any duplicates found in the file.